### PR TITLE
Create assign-milestone-on-close.yml

### DIFF
--- a/.github/workflows/assign-milestone-on-close.yml
+++ b/.github/workflows/assign-milestone-on-close.yml
@@ -1,0 +1,45 @@
+name: Assign Milestone on Close
+
+env:
+  MILESTONE_ID: ${{ vars.MILESTONE_ID }}
+
+on:
+  issues:
+    types: [closed]
+  pull_request_target:
+    types: [closed]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  assign-milestone:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if milestone is set
+        id: check-milestone
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const issueOrPr = context.payload.issue || context.payload.pull_request;
+            if (!issueOrPr.milestone) {
+              core.setOutput('milestoneNotSet', 'true');
+            } else {
+              core.setOutput('milestoneNotSet', 'false');
+            }
+
+      - name: Assign default milestone
+        if: steps.check-milestone.outputs.milestoneNotSet == 'true'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const issueOrPrNumber = (context.payload.issue || context.payload.pull_request).number;
+            const repository = context.repo;
+            await github.rest.issues.update({
+              ...repository,
+              issue_number: issueOrPrNumber,
+              milestone: process.env.MILESTONE_ID
+            });


### PR DESCRIPTION
<!-- Please read and fill in the following template, for an explanation of the sections see:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md
Please also note that the NVDA project has a Citizen and Contributor Code of Conduct which can be found at https://github.com/nvaccess/nvda/blob/master/CODE_OF_CONDUCT.md. NV Access expects that all contributors and other community members read and abide by the rules set out in this document while participating or contributing to this project. This includes creating or commenting on issues and pull requests. 

Please initially open PRs as a draft.
When you would like a review, mark the PR as "ready for review". 
See https://github.com/nvaccess/nvda/blob/master/.github/CONTRIBUTING.md.
-->

### Link to issue number:

### Summary of the issue:

### Description of user facing changes

### Description of development approach

### Testing strategy:

### Known issues with pull request:

### Code Review Checklist:

<!--
This checklist is a reminder of things commonly forgotten in a new PR.
Authors, please do a self-review of this pull-request.
Check items to confirm you have thought about the relevance of the item.
Where items are missing (eg unit / system tests), please explain in the PR.
To check an item `- [ ]` becomes `- [x]`, note spacing.
You can also check the checkboxes after the PR is created.
A detailed explanation of this checklist is available here:
https://github.com/nvaccess/nvda/blob/master/projectDocs/dev/githubPullRequestTemplateExplanationAndExamples.md#code-review-checklist
-->

- [ ] Documentation:
  - Change log entry
  - User Documentation
  - Developer / Technical Documentation
  - Context sensitive help for GUI changes
- [ ] Testing:
  - Unit tests
  - System (end to end) tests
  - Manual testing
- [ ] UX of all users considered:
  - Speech 
  - Braille
  - Low Vision
  - Different web browsers
  - Localization in other languages / culture than English
- [ ] API is compatible with existing add-ons.
- [ ] Security precautions taken.
